### PR TITLE
Fix code in "execution_count": 56

### DIFF
--- a/python_expert_notebook.ipynb
+++ b/python_expert_notebook.ipynb
@@ -883,9 +883,9 @@
     }
    ],
    "source": [
-    "print('add(10)'), timer(add, 10)\n",
-    "print('add(20, 30)'), timer(add, 20, 30)\n",
-    "print('add(\"a\", \"b\")', timer(add, \"a\", \"b\")"
+    "print('add(10)', timer(add, 10))\n",
+    "print('add(20, 30)', timer(add, 20, 30))\n",
+    "print('add(\"a\", \"b\"', timer(add, \"a\", \"b\"))"
    ]
   },
   {


### PR DESCRIPTION
There is an error in the code:

After:
print('add(10)'), timer(add, 10)
print('add(20, 30)'), timer(add, 20, 30)
print('add("a", "b")', timer(add, "a", "b")


Before:
print('add(10)', timer(add, 10))
print('add(20, 30)', timer(add, 20, 30))
print('add("a", "b"', timer(add, "a", "b"))